### PR TITLE
カート機能追加、complete(注文完了画面)のURLを変更、データベース修正

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -1,24 +1,26 @@
 class Public::CartItemsController < ApplicationController
   
   def index
-    @cart_items = CartItem.all
+    @cart_items = current_customer.cart_items.all
+    @total_price = @cart_items.inject(0) { |sum, item| sum + item.total_price }
   end
   
   def update
     cart_item = CartItem.find(params[:id])
     cart_item.update(cart_item_params)
-    redirect_to cart_item_path
+    redirect_to cart_items_path
   end
   
   def destroy
     cart_item = CartItem.find(params[:id])
     cart_item.destroy
-    redirect_to cart_item_path
+    redirect_to cart_items_path
   end
   
   def destroy_all
-    cart_items = current_customer.cart_items
+    cart_items = current_customer.cart_items.all
     cart_items.destroy_all
+    redirect_to cart_items_path
   end
   
   def create
@@ -30,7 +32,7 @@ class Public::CartItemsController < ApplicationController
       cart_item.customer_id = current_customer.id
       cart_item.save
     end
-    redirect_to cart_item_path
+    redirect_to cart_items_path
   end
   
   private

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -11,10 +11,10 @@ def new
 end
     
 def confirm
-    @cart_items = current_customer.cart_items ##ログインカスタマーのカート内アイテムを指定
+    @cart_items = current_customer.cart_items.all ##ログインカスタマーのカート内アイテムを指定
     @order = Order.new(order_params) ##オーダー新規登録
     @order.payment_method = params[:order][:payment_method] ##支払方法を反映
-    @total_price = @cart_items.inject(0) { |sum, item| sum + item.sum_of_price } ##cart_itemsから1つずつ取り出して合計金額が出せるらしい
+    @total_price = @cart_items.inject(0) { |sum, item| sum + item.total_price } ##cart_itemsから1つずつ取り出して合計金額が出せるらしい
     @order.postage = 800 ##配達料金は800円
     
     ## ご自身の住所から選択
@@ -56,16 +56,19 @@ end
 def create
     @order = Order.new(order_params) ##オーダー新規作成
     @order.customer_id = current_customer.id ##オーダーカスタマーIDをログインしているカスタマーIDに指定
+    @cart_items = current_customer.cart_items.all ##カート内アイテムにログインしているカスタマーのカート内アイテムを反映
+    
     if @order.save ## 保存
-        @cart_items = current_customer.cart_items ##カート内アイテムにログインしているカスタマーのカート内アイテムを反映
-        
         @cart_items.each do |cart_item| ## カート内アイテムを1つずつ取り出す---------------
-            order_item = OrderItem.new(order_id: @order.id) ##取り出すたびにIDを指定（？）  |
-            order_item.price = cart_item.item.price * 1.1 ##消費税を反映させる              |
-            order_item.quantiy = cart_item.quantiy ##数量を反映させる                       |        
+            order_item = OrderItem.new ##新規作成
+            order_item.order_id = @order.id ##order_idにidを反映させる                      |
             order_item.item_id = cart_item.item_id ##商品を反映させる                       |
+            order_item.quantity = cart_item.quantity ##数量を反映させる                       | 
+            order_item.purchase_price = cart_item.item.price * 1.1 ##消費税を反映させる     |
+            order_item.production_status = 0 ##status                                       |
             order_item.save ##保存                                                         \|/ 繰り返し
         end
+        
         
         @cart_items.destroy_all ##カート内アイテムはもういらないから消す（まだdestroy_all使用不可）
         redirect_to complete_path ##注文完了画面に変移
@@ -75,7 +78,7 @@ def create
 end
 
 def index
-    @orders = current_customer.orders
+    @orders = current_customer.orders.all
 end
     
 def show

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -1,19 +1,13 @@
 class CartItem < ApplicationRecord
-  
+
   belongs_to :customer
   belongs_to :item
-  
+
   ############
-  
+
+  ##商品の金額×数量で合計金額を求める
   def total_price
-    item.purchase_price * quantity
+    (item.price * 1.1).floor * quantity
   end
-  
-  def self.cart_items_total_price(cart_items)
-    array = []
-    cart_items.each do |cart_item|
-      array << cart_item.item.purchase_price * cart_item.quantity
-    end
-    return(array.sum * 1.1).floor.to_s(:delimited)
-  end
+
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,8 +18,9 @@ class Item < ApplicationRecord
   
   #################
   
+  ## 商品の金額に消費税10%を反映させる（to_s(:delimted)で3桁ごとに,を反映させる）
   def purchase_price
-    (price * 1.1).floor.floor.to_s(:delimited)
+    (price * 1.1).floor.to_s(:delimited)
   end
   
   has_one_attached :image

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -1,9 +1,14 @@
 <div class="container">
-    <div class="row">
-        <h3>ショッピングカート</h3>
-        <
+    <div class="row mt-4">
+        <div class="col-7">
+            <h3>ショッピングカート</h3>
+        </div>
+        
+        <div class="col-4">
+            <%= link_to "カートを空にする", destroy_all_path, method: :delete, data: { confirm: '本当に消しますか？' },  class: "btn btn-danger" %>
+        </div>
     </div>
-    <div class="row">
+    <div class="row mt-4">
         <div class="table-responsive">
             <table class="table table-bordered">
                 <thead>
@@ -19,17 +24,37 @@
                     <tbody>
                         <tr>
                             <td>
-                                <%= image_tag cart_item.get_image(100, 100) %>
+                                <%= image_tag cart_item.item.get_image(100, 100) %>
                                 <%= cart_item.item.name %>
                             </td>
-                            <td><%= cart_item.item.purchase_price %></td>
-                            <td><%= cart_item.quantity %>円</td>
-                            <td><%= cart_item.total_price %></td>
-                            <td><%= link_to "削除する", order_path(order.id), class: "btn btn-outline-primary" %></td>
+                            <td>¥<%= cart_item.item.purchase_price %></td>
+                            <td><%= cart_item.quantity %></td>
+                            <td>¥<%= cart_item.total_price.to_s(:delimited) %></td>
+                            <td><%= link_to "削除する", cart_item_path(cart_item.id), method: :delete, data: { confirm: '本当に消しますか？' },  class: "btn btn-danger" %></td>
                         </tr>
                     </tbody>
                 <% end %>
             </table>
+        </div>
+    </div>
+    <div class="row mt-4">
+        <div class="col-5">
+            <%= link_to "買い物を続ける", items_path, class: "btn btn-primary" %>
+        </div>
+        <div class="col-6">
+            <table class="table table-bordered">
+                <tr>
+                    <td>合計金額</td>
+                    <td>¥<%= @total_price.to_s(:delimited) %></td>
+                </tr>
+            </table>
+        </div>
+    </div>
+    <div class="row mt-4 mb-4">
+        <div class="col text-center">
+            <% if @cart_items.any? %>
+            <%= link_to "情報入力に進む", new_order_path, class: "btn btn-success" %>
+            <% end %>
         </div>
     </div>
 </div>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -22,8 +22,8 @@
                                 <%= cart_item.item.name %>
                             </td>
                             <td>¥<%= (cart_item.item.price * 1.1).floor.to_s(:delimited) %></td>
-                            <td><%= cart_item.quantiy %></td>
-                            <td>¥<%= (cart_item.item.price * cart_item.quantiy * 1.1).floor.to_s(:delimited) %></td>
+                            <td><%= cart_item.quantity %></td>
+                            <td>¥<%= (cart_item.item.price * cart_item.quantity * 1.1).floor.to_s(:delimited) %></td>
                         </tr>
                     </tbody>
                     <% end %>
@@ -33,7 +33,7 @@
         <div class="col-4">
             <div class="table-responsive">
                 <table class="table table-bordered">
-                    <%= form_with model: @order, url: complete_path, local:true do |f| %>
+                    <%= form_with model: @order, url: orders_path, method: :post, local:true do |f| %>
                     <tr>
                         <td>送料</td>
                         <td>
@@ -64,6 +64,7 @@
                 </div>
                 <div class="col-8">
                     <h4><%= @order.payment_method %></h4>
+                    <%= f.hidden_field :payment_method, :value => @order.payment_method %>
                 </div>
             </div>
             <div class="row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ scope module: :public do
   delete "cart_items/destroy_all" => "cart_items#destroy_all" , as: "destroy_all"
   resources :orders, only: [:new,:create,:index,:show]
   post "orders/confirm" => "orders#confirm", as: "confirm"
-  post "orders/complete" => "orders#complete", as: "complete"
+  get "complete" => "orders#complete", as: "complete"
   resources :deliveries, except: [:show]
   end
 

--- a/db/migrate/20221116022719_create_cart_items.rb
+++ b/db/migrate/20221116022719_create_cart_items.rb
@@ -4,7 +4,7 @@ class CreateCartItems < ActiveRecord::Migration[6.1]
 
       t.integer :customer_id, null: false
       t.integer :item_id, null: false
-      t.integer :quantiy, null: false
+      t.integer :quantity, null: false
 
       t.timestamps
     end

--- a/db/migrate/20221116023058_create_order_items.rb
+++ b/db/migrate/20221116023058_create_order_items.rb
@@ -4,7 +4,7 @@ class CreateOrderItems < ActiveRecord::Migration[6.1]
 
       t.integer :order_id, null: false
       t.integer :item_id, null: false
-      t.integer :quantiy, null: false
+      t.integer :quantity, null: false
       t.integer :production_status, null: false, default: "0"
       t.integer :purchase_price, null: false
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 2022_11_16_023058) do
   create_table "cart_items", force: :cascade do |t|
     t.integer "customer_id", null: false
     t.integer "item_id", null: false
-    t.integer "quantiy", null: false
+    t.integer "quantity", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -108,7 +108,7 @@ ActiveRecord::Schema.define(version: 2022_11_16_023058) do
   create_table "order_items", force: :cascade do |t|
     t.integer "order_id", null: false
     t.integer "item_id", null: false
-    t.integer "quantiy", null: false
+    t.integer "quantity", null: false
     t.integer "production_status", default: 0, null: false
     t.integer "purchase_price", null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
カート機能追加
商品詳細ページからカートに入れるでカートに追加可能になります。
情報入力に進むから注文情報入力に変移
ショッピングカートのDestroy_allは未実装
注文情報確認画面から注文を確定するを押すと注文を確定することが出来ます。
注文後⇒注文履歴に注文情報が表示される

complete(注文完了画面)のURLを変更しました。
orders/completeだとshow扱いになってしまうため、
/complete に変更

データベースのorder_itemとcart_itemのquantityがquantiyになっていたため修正
お手数ですが反映後にdb:migrate:resetをお願いします。